### PR TITLE
Add numpad shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the "zoomer" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.3.1] 2024-05-20
+
+- Add support for Numpad
+
+Zoom In:
+
+- Mac `Command` + `numpad_add`
+- Windows `Control` + `numpad_add`
+- Linux `Control` + `numpad_add`
+
+Zoom Out:
+
+- Mac `Command` + `numpad_subtract`
+- Windows `Control` + `numpad_subtract`
+- Linux `Control` + `numpad_subtract`
+
 ## [0.3.0] 2024-05-19
 
 - Update .gitignore

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ Zoom Out:
 - Windows `Control` + `-`
 - Linux `Control` + `-`
 
+Also works with numpad.
+
+Zoom In:
+
+- Mac `Command` + `numpad_add`
+- Windows `Control` + `numpad_add`
+- Linux `Control` + `numpad_add`
+
+Zoom Out:
+
+- Mac `Command` + `numpad_subtract`
+- Windows `Control` + `numpad_subtract`
+- Linux `Control` + `numpad_subtract`
+
 ### Settings
 
 Head to Zoomer settings in Code and set your custom zoom factor!

--- a/package.json
+++ b/package.json
@@ -60,9 +60,19 @@
         "mac": "cmd+="
       },
       {
+        "command": "zoomer.zoomIns",
+        "key": "ctrl+numpad_add",
+        "mac": "cmd+numpad_add"
+      },
+      {
         "command": "zoomer.zoomOuts",
         "key": "ctrl+-",
         "mac": "cmd+-"
+      },
+      {
+        "command": "zoomer.zoomOuts",
+        "key": "ctrl+numpad_subtract",
+        "mac": "cmd+numpad_subtract"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zoomer",
   "displayName": "Zoomer",
   "description": "Finely tune your zoom levels to get the perfectly sized text",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "anthonyattard",
   "engines": {
     "vscode": "^1.65.0"


### PR DESCRIPTION
Zoom In:

- Mac `Command` + `numpad_add`
- Windows `Control` + `numpad_add`
- Linux `Control` + `numpad_add`

Zoom Out:

- Mac `Command` + `numpad_subtract`
- Windows `Control` + `numpad_subtract`
- Linux `Control` + `numpad_subtract`